### PR TITLE
feat: allow bypassing the order preview step during checkout

### DIFF
--- a/oscar_stripe_sca/apps.py
+++ b/oscar_stripe_sca/apps.py
@@ -5,32 +5,51 @@ from django.urls import path
 
 class StripeSCACheckoutConfig(CheckoutConfig):
     def ready(self):
-        stripe_payment_details_view = get_class(
-            "oscar_stripe_sca.views", "StripeSCAPaymentDetailsView"
+        self.payment_details_view = get_class(
+            "oscar_stripe_sca.views", "StripeSCACheckoutView"
         )
-        stripe_success_view = get_class(
-            "oscar_stripe_sca.views", "StripeSCASuccessResponseView"
+        self.stripe_preview_view = get_class(
+            "oscar_stripe_sca.views", "StripeSCAPreviewView"
         )
-        stripe_cancel_view = get_class(
-            "oscar_stripe_sca.views", "StripeSCACancelResponseView"
+        self.stripe_webhook_view = get_class(
+            "oscar_stripe_sca.views", "StripeSCAWebhookView"
+        )
+        self.stripe_waiting_view = get_class(
+            "oscar_stripe_sca.views", "StripeSCAWaitingView"
+        )
+        self.stripe_payment_status_view = get_class(
+            "oscar_stripe_sca.views", "StripeSCAPaymentStatusView"
+        )
+        self.stripe_cancel_view = get_class(
+            "oscar_stripe_sca.views", "StripeSCACancelView"
         )
         super().ready()
 
     def get_urls(self):
-        urls = super(StripeSCACheckoutConfig, self).get_urls()
+        urls = super().get_urls()
         urls += [
             path(
-                "payment-details-stripe/",
-                self.stripe_payment_details_view.as_view(),
-                name="stripe-payment-details",
-            ),
-            path(
-                "preview-stripe/<int:basket_id>/",
-                self.stripe_success_view.as_view(preview=True),
+                "stripe/preview/<int:basket_id>/",
+                self.stripe_preview_view.as_view(preview=True),
                 name="stripe-preview",
             ),
             path(
-                "payment-cancel/<int:basket_id>/",
+                "stripe/webhook/",
+                self.stripe_webhook_view.as_view(),
+                name="stripe-webhook",
+            ),
+            path(
+                "stripe/waiting/",
+                self.stripe_waiting_view.as_view(),
+                name="stripe-waiting",
+            ),
+            path(
+                "stripe/payment-status/",
+                self.stripe_payment_status_view.as_view(),
+                name="stripe-payment-status",
+            ),
+            path(
+                "stripe/cancel/<int:basket_id>/",
                 self.stripe_cancel_view.as_view(),
                 name="stripe-cancel",
             ),

--- a/oscar_stripe_sca/constants.py
+++ b/oscar_stripe_sca/constants.py
@@ -1,6 +1,30 @@
-CAPTURE_METHOD_MANUAL = "manual"
 PACKAGE_NAME = "oscar_stripe_sca"
+
+SESSION_MODE_PAYMENT = "payment"
+
 PAYMENT_EVENT_PURCHASE = "Purchase"
+
 PAYMENT_METHOD_STRIPE = "Stripe"
 PAYMENT_METHOD_TYPE_CARD = "card"
-SESSION_MODE_PAYMENT = "payment"
+
+CAPTURE_METHOD_MANUAL = "manual"
+CAPTURE_METHOD_AUTOMATIC = "automatic"
+
+# https://support.stripe.com/questions/which-zero-decimal-currencies-does-stripe-support
+ZERO_DECIMAL_CURRENCIES = (
+    "BIF",  # Burundian Franc
+    "CLP",  # Chilean Peso
+    "DJF",  # Djiboutian Franc
+    "GNF",  # Guinean Franc
+    "JPY",  # Japanese Yen
+    "KMF",  # Comorian Franc
+    "KRW",  # South Korean Won
+    "MGA",  # Malagasy Ariary
+    "PYG",  # Paraguayan Guaraní
+    "RWF",  # Rwandan Franc
+    "VND",  # Vietnamese Đồng
+    "VUV",  # Vanuatu Vatu
+    "XAF",  # Central African Cfa Franc
+    "XOF",  # West African Cfa Franc
+    "XPF",  # Cfp Franc
+)

--- a/oscar_stripe_sca/exceptions.py
+++ b/oscar_stripe_sca/exceptions.py
@@ -1,4 +1,7 @@
-class MultipleTaxCodesInBasket(ValueError):
+from stripe.error import SignatureVerificationError
+
+
+class MultipleTaxCodesInBasketError(ValueError):
     pass
 
 

--- a/oscar_stripe_sca/mixins.py
+++ b/oscar_stripe_sca/mixins.py
@@ -1,0 +1,225 @@
+import logging
+
+from django.contrib import messages
+from django.utils.module_loading import import_string
+from django.utils.translation import gettext_lazy as _
+
+from oscar.core.loading import get_class, get_model
+from oscar.core.exceptions import ModuleNotFoundError
+
+from . import settings
+from .constants import PAYMENT_EVENT_PURCHASE, PAYMENT_METHOD_STRIPE
+
+
+logger = logging.getLogger(settings.STRIPE_LOGGER_NAME)
+
+Facade = import_string(settings.STRIPE_FACADE_CLASS_PATH)
+
+Basket = get_model("basket", "Basket")
+OfferApplicator = get_class("offer.applicator", "Applicator")
+PaymentSource = get_model("payment", "Source")
+PaymentSourceType = get_model("payment", "SourceType")
+ShippingRepository = get_class("shipping.repository", "Repository")
+StrategySelector = get_class("partner.strategy", "Selector")
+SurchargeApplicator = get_class("checkout.applicator", "SurchargeApplicator")
+TaxInclusiveFixedPrice = get_class("partner.prices", "TaxInclusiveFixedPrice")
+UnableToPlaceOrder = get_class("order.exceptions", "UnableToPlaceOrder")
+
+
+class StripePaymentMixin(object):
+
+    def __init__(self, *args, **kwargs):
+        self.facade = Facade()
+
+    def load_frozen_basket(self, basket_id, user=None, request=None):
+        try:
+            basket = Basket.objects.get(id=basket_id, status=Basket.FROZEN)
+        except Basket.DoesNotExist:
+            logger.warning("Unable to load frozen basket with ID %s", basket_id)
+            if request:
+                messages.error(
+                    request,
+                    _("No basket was found for your Stripe transaction"),
+                )
+            return None
+
+        # Assign strategy to basket instance
+        if StrategySelector:
+            basket.strategy = StrategySelector().strategy(request)
+
+        # Re-apply any offers
+        OfferApplicator().apply(basket, user=user, request=request)
+
+        return basket
+
+    def build_submission(self, basket, **kwargs):
+        user = kwargs.pop("user", basket.owner)
+        shipping_address = self.get_shipping_address(basket)
+        shipping_method = kwargs.pop(
+            "shipping_method", self.get_shipping_method(basket, shipping_address)
+        )
+        billing_address = self.get_billing_address(shipping_address)
+
+        submission = {
+            "user": user,
+            "basket": basket,
+            "shipping_address": shipping_address,
+            "shipping_method": shipping_method,
+            "billing_address": billing_address,
+            "order_kwargs": {},
+            "payment_kwargs": {},
+        }
+
+        if not shipping_method:
+            order_total = shipping_charge = surcharges = None
+        else:
+            request = kwargs.pop("request", None)
+            shipping_charge = shipping_method.calculate(basket)
+            surcharges = SurchargeApplicator(
+                request, submission
+            ).get_applicable_surcharges(basket, shipping_charge=shipping_charge)
+            order_total = self.get_order_totals(
+                basket,
+                shipping_charge=shipping_charge,
+                surcharges=surcharges,
+                **kwargs,
+            )
+
+        submission.update(
+            {
+                "shipping_charge": shipping_charge,
+                "surcharges": surcharges,
+                "order_total": order_total,
+            }
+        )
+        if billing_address:
+            submission["payment_kwargs"]["billing_address"] = billing_address
+
+        # Allow overrides to be passed in
+        submission.update(kwargs)
+        logger.debug(f"*** submission: {submission}")
+
+        return submission
+
+    def add_payment_details(self, order_total, payment_intent_id):
+        payment_source_type, __ = PaymentSourceType.objects.get_or_create(
+            name=PAYMENT_METHOD_STRIPE
+        )
+        payment_source = PaymentSource(
+            source_type=payment_source_type,
+            amount_allocated=order_total.incl_tax,
+            amount_debited=order_total.incl_tax,
+            currency=order_total.currency,
+            reference=payment_intent_id,
+        )
+        self.add_payment_source(payment_source)
+        self.add_payment_event(
+            PAYMENT_EVENT_PURCHASE,
+            order_total.incl_tax,
+            reference=payment_intent_id,
+        )
+
+
+class TwoStepPaymentMixin(StripePaymentMixin):
+
+    def submit_basket(self, basket):
+        submission = self.build_submission(basket)
+        return self.submit(**submission)
+
+    def handle_payment(self, order_number, order_total, **kwargs):
+        checkout_session_id = self.request.session["stripe_session_id"]
+
+        payment_intent_id = self.facade.retrieve_payment_intent_id(
+            checkout_session_id=checkout_session_id
+        )
+        self.facade.capture_payment_intent(payment_intent_id=payment_intent_id)
+        self.add_payment_details(
+            order_total=order_total,
+            payment_intent_id=payment_intent_id,
+        )
+
+        del self.request.session["stripe_session_id"]
+
+
+class OneStepPaymentMixin(StripePaymentMixin):
+
+    def _get_shipping_method(self, basket, code):
+        shipping_methods = ShippingRepository().get_shipping_methods(basket)
+        for shipping_method in shipping_methods:
+            if shipping_method.code == code:
+                return shipping_method
+
+    def _retrieve_shipping_method(self, basket, payment_intent_data):
+        try:
+            code = payment_intent_data["metadata"]["shipping_method"]
+        except KeyError:
+            return None
+        else:
+            return self._get_shipping_method(basket, code)
+
+    def build_submission(self, basket, payment_intent_data, **kwargs):
+        shipping_method = self._retrieve_shipping_method(basket, payment_intent_data)
+        logger.debug(f"*** shipping_method: {shipping_method}")
+
+        return super().build_submission(basket=basket, shipping_method=shipping_method)
+
+    def submit_basket(self, basket, payment_intent_data):
+        submission = self.build_submission(basket, payment_intent_data)
+        self.add_payment_details(
+            order_total=submission["order_total"],
+            payment_intent_id=payment_intent_data["id"],
+        )
+        self.submit(**submission)
+
+    def submit(
+        self,
+        user,
+        basket,
+        shipping_address,
+        shipping_method,
+        shipping_charge,
+        billing_address,
+        order_total,
+        order_kwargs=None,
+        payment_kwargs=None,
+        surcharges=None,
+    ):
+        order_number = self.generate_order_number(basket)
+        try:
+            self.handle_order_placement(
+                order_number,
+                user,
+                basket,
+                shipping_address,
+                shipping_method,
+                shipping_charge,
+                billing_address,
+                order_total,
+                surcharges=surcharges,
+                **order_kwargs,
+            )
+
+        except UnableToPlaceOrder as ex:
+
+            # It's possible that something will go wrong while trying to
+            # actually place an order. Not a good situation to be in as a
+            # payment transaction may already have taken place, but needs
+            # to be handled gracefully.
+            msg = str(ex)
+            logger.error(
+                "*** Order #%s: unable to place order - %s",
+                order_number,
+                msg,
+                exc_info=True,
+            )
+
+        except Exception as ex:
+
+            # Hopefully you only ever reach this in development...
+            msg = str(ex)
+            logger.exception(
+                "*** Order #%s: unhandled exception while placing order (%s)",
+                order_number,
+                msg,
+                exc_info=True,
+            )

--- a/oscar_stripe_sca/settings.py
+++ b/oscar_stripe_sca/settings.py
@@ -3,45 +3,30 @@ from django.conf import settings
 from .constants import PACKAGE_NAME
 
 
-STRIPE_LOGGER_NAME = getattr(
-    settings, "STRIPE_LOGGER_NAME", PACKAGE_NAME
-)
+STRIPE_LOGGER_NAME = getattr(settings, "STRIPE_LOGGER_NAME", PACKAGE_NAME)
 
 STRIPE_FACADE_CLASS_PATH = getattr(
     settings, "STRIPE_FACADE_CLASS_PATH", f"{PACKAGE_NAME}.facade.Facade"
 )
 
-STRIPE_API_VERSION = getattr(
-    settings, "STRIPE_API_VERSION", "2020-03-02"
-)
+STRIPE_API_VERSION = getattr(settings, "STRIPE_API_VERSION", "2025-06-30.basil")
 
-STRIPE_PUBLISHABLE_KEY = getattr(
-    settings, "STRIPE_PUBLISHABLE_KEY", None
-)
-
-STRIPE_SECRET_KEY = getattr(
-    settings, "STRIPE_SECRET_KEY", None
-)
+STRIPE_PUBLISHABLE_KEY = getattr(settings, "STRIPE_PUBLISHABLE_KEY", None)
+STRIPE_SECRET_KEY = getattr(settings, "STRIPE_SECRET_KEY", None)
 
 STRIPE_RETURN_URL_BASE = getattr(
     settings, "STRIPE_RETURN_URL_BASE", "http://localhost/"
 )
-
-STRIPE_PAYMENT_SUCCESS_URL = getattr(
-    settings, "STRIPE_PAYMENT_SUCCESS_URL", None  # lazy if missing
+STRIPE_ORDER_PREVIEW_URL = getattr(settings, "STRIPE_ORDER_PREVIEW_URL", None)
+STRIPE_WEBHOOK_URL = getattr(settings, "STRIPE_WEBHOOK_URL", None)
+STRIPE_WAITING_FOR_PAYMENT_URL = getattr(
+    settings, "STRIPE_WAITING_FOR_PAYMENT_URL", None
 )
+STRIPE_PAYMENT_STATUS_URL = getattr(settings, "STRIPE_PAYMENT_STATUS_URL", None)
+STRIPE_ORDER_CONFIRMATION_URL = getattr(settings, "STRIPE_ORDER_CONFIRMATION_URL", None)
+STRIPE_CANCEL_URL = getattr(settings, "STRIPE_CANCEL_URL", None)
 
-STRIPE_PAYMENT_CANCEL_URL = getattr(
-    settings, "STRIPE_PAYMENT_CANCEL_URL", None  # lazy if missing
-)
-
-STRIPE_SEND_RECEIPT = getattr(
-    settings, "STRIPE_SEND_RECEIPT", True
-)
-
-STRIPE_USE_PRICES_API = getattr(
-    settings, "STRIPE_USE_PRICES_API", True
-)
+STRIPE_USE_PRICES_API = getattr(settings, "STRIPE_USE_PRICES_API", True)
 
 STRIPE_COMPRESS_TO_ONE_LINE_ITEM = getattr(
     settings, "STRIPE_COMPRESS_TO_ONE_LINE_ITEM", False
@@ -50,12 +35,21 @@ STRIPE_COMPRESS_TO_ONE_LINE_ITEM = getattr(
 STRIPE_ENABLE_TAX_COMPUTATION = getattr(
     settings, "STRIPE_ENABLE_TAX_COMPUTATION", False
 )
-
 STRIPE_DEFAULT_PRODUCT_TAX_CODE = getattr(
     settings, "STRIPE_DEFAULT_PRODUCT_TAX_CODE", None
 )
-
 STRIPE_DEFAULT_SHIPPING_TAX_CODE = getattr(
     settings, "STRIPE_DEFAULT_SHIPPING_TAX_CODE", "txcd_92010001"
 )
 # See: https://docs.stripe.com/tax/tax-codes?tax_code=shipping
+
+STRIPE_BYPASS_ORDER_PREVIEW = getattr(settings, "STRIPE_BYPASS_ORDER_PREVIEW", False)
+STRIPE_WAIT_FOR_PAYMENT_CONFIRMATION = getattr(
+    settings, "STRIPE_WAIT_FOR_PAYMENT_CONFIRMATION", True
+)
+STRIPE_PAYMENT_POLLING_INTERVAL = getattr(
+    settings, "STRIPE_PAYMENT_POLLING_INTERVAL", 1000  # in milliseconds
+)
+STRIPE_WEBHOOK_ENDPOINT_SECRET = getattr(
+    settings, "STRIPE_WEBHOOK_ENDPOINT_SECRET", None
+)

--- a/oscar_stripe_sca/templates/oscar_stripe_sca/stripe_checkout.html
+++ b/oscar_stripe_sca/templates/oscar_stripe_sca/stripe_checkout.html
@@ -1,8 +1,9 @@
 {% extends 'oscar/checkout/payment_details.html' %}
-{% load i18n static %}
-{% load currency_filters %}
+{% load i18n static currency_filters %}
 
-{% block checkout_title %}{% translate "Checkout" %}{% endblock %}
+{% block checkout_title %}
+    {% translate "Checkout" %}
+{% endblock %}
 
 {% block checkout_nav %}
     {% include 'oscar/checkout/nav.html' with step=3 %}
@@ -12,7 +13,6 @@
 {% block shipping_address %}{% endblock %}
 {% block shipping_method %}{% endblock %}
 {% block payment_method %}{% endblock %}
-
 
 {% block payment_details_content %}
     <p>Launching Stripe, please wait...</p>

--- a/oscar_stripe_sca/templates/oscar_stripe_sca/stripe_preview.html
+++ b/oscar_stripe_sca/templates/oscar_stripe_sca/stripe_preview.html
@@ -11,13 +11,15 @@
             <h2>Payment</h2>
         </div>
         <div class="well well-success">
-            <p class="text-danger font-weight-bold" >Your order is not complete until you click the "Place order" button.</p>
+            <p class="text-danger font-weight-bold">
+                Your order is not complete until you click the "Place order" button.
+            </p>
             <div>
                 <form method="post" action="" id="place_order_form">
                     {% csrf_token %}
                     <input type="hidden" name="action" value="place_order" />
                     <div style="display:none">
-                            {{ stripe_token_form.as_p }}
+                        {{ stripe_token_form.as_p }}
                     </div>
                     <input id='place-order' type="submit" value="{% translate "Place order" %}" data-loading-text="Placing order..." class="btn-block btn btn-primary btn-large" />
                 </form>
@@ -34,6 +36,11 @@
     <form method="post" action="" id="place_order_form">
         {% csrf_token %}
         <input type="hidden" name="action" value="place_order" />
+        <div style="display:none">
+            {% block hiddenforms %}
+                {{ stripe_token_form.as_p }}
+            {% endblock %}
+        </div>
 
         {% comment %}
             When submitting sensitive data on the payment details page (eg a bankcard)
@@ -41,18 +48,15 @@
             template and render it in a hidden div. Then the payment information will
             get re-submitted when the user confirms the order.
         {% endcomment %}
-        <div style="display:none">
-            {% block hiddenforms %}
-{#                {{ stripe_token_form.as_p }}#}
-            {% endblock %}
-        </div>
 
         <div class="form-actions clearfix">
             <div class="row">
                 <div class="col-xs-12 col-sm-6 col-md-3 col-sm-offset-6 col-md-offset-9">
-                     <button id='place-order' type="submit" class="btn btn-primary btn-large btn-block" data-loading-text="{% translate 'Placing order...' %}">{% translate "Place order" %}</button>
+                     <button id='place-order' type="submit" class="btn btn-primary btn-large btn-block" data-loading-text="{% translate 'Placing order...' %}">
+                        {% translate "Place order" %}
+                    </button>
                 </div>
             </div>
         </div>
     </form>
-{% endblock place_order %}
+{% endblock %}

--- a/oscar_stripe_sca/templates/oscar_stripe_sca/stripe_waiting.html
+++ b/oscar_stripe_sca/templates/oscar_stripe_sca/stripe_waiting.html
@@ -1,0 +1,54 @@
+{% extends 'oscar/checkout/payment_details.html' %}
+{% load i18n static currency_filters %}
+
+{% block checkout_title %}
+    {% translate "Checkout" %}
+{% endblock %}
+
+{% block checkout_nav %}
+    {% include 'oscar/checkout/nav.html' with step=4 %}
+{% endblock %}
+
+{% block order_contents %}{% endblock %}
+{% block shipping_address %}{% endblock %}
+{% block shipping_method %}{% endblock %}
+{% block payment_method %}{% endblock %}
+
+{% block payment_details_content %}
+    <p>Waiting for order confirmation, please wait...</p>
+
+    <script type="text/javascript">
+
+        const statusUrl = "{{ payment_status_url }}",
+              successUrl = "{{ payment_success_url }}",
+              pollingInterval = {{ polling_interval }};
+
+        window.addEventListener("load", (event) => {
+            setInterval(() => {
+
+                fetch(statusUrl, {
+                    method: "GET",
+                    headers: {
+                        "Accept": "application/json",
+                    }
+                })
+                .then((response) => response.json())
+                .then((data) => {
+
+                    console.debug("*** Received payment info: ", data);
+                    const isPaymentSuccessful = data.isSuccessful;
+                    if (isPaymentSuccessful) {
+                        window.location = successUrl;
+                    };
+
+                }).catch((error) => {
+
+                    console.error("*** Error: ", error);
+
+                });
+
+            }, pollingInterval);
+        });
+
+    </script>
+{% endblock %}

--- a/oscar_stripe_sca/views.py
+++ b/oscar_stripe_sca/views.py
@@ -2,14 +2,14 @@ import logging
 
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
-from django.http import HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
-from django.views.generic import RedirectView
+from django.views.generic import RedirectView, TemplateView, View
 
 from oscar.apps.checkout.views import PaymentDetailsView as CorePaymentDetailsView
 from oscar.core.exceptions import ModuleNotFoundError
@@ -21,62 +21,56 @@ from .constants import (
     PAYMENT_EVENT_PURCHASE,
     PAYMENT_METHOD_STRIPE,
 )
+from .exceptions import SignatureVerificationError
+from .mixins import OneStepPaymentMixin, StripePaymentMixin, TwoStepPaymentMixin
 
 
 logger = logging.getLogger(settings.STRIPE_LOGGER_NAME)
 
 Facade = import_string(settings.STRIPE_FACADE_CLASS_PATH)
 
-SourceType = get_model("payment", "SourceType")
-Source = get_model("payment", "Source")
-Line = get_model("basket", "Line")
 Basket = get_model("basket", "Basket")
-Selector = get_class("partner.strategy", "Selector")
-try:
-    Applicator = get_class("offer.applicator", "Applicator")
-except ModuleNotFoundError:
-    # fallback for django-oscar<=1.1
-    Applicator = get_class("offer.utils", "Applicator")
+Line = get_model("basket", "Line")
+PaymentEvent = get_model("order", "PaymentEvent")
+
+OrderPlacementMixin = get_class("checkout.mixins", "OrderPlacementMixin")
 
 
-class StripeSCAPaymentDetailsView(CorePaymentDetailsView):
-    template_name = f"{PACKAGE_NAME}/stripe_payment_details.html"
+class StripeSCACheckoutView(CorePaymentDetailsView):
+    template_name = f"{PACKAGE_NAME}/stripe_checkout.html"
 
     def get_context_data(self, **kwargs):
         context_data = super().get_context_data(**kwargs)
 
         basket = context_data["basket"]
-        total = context_data["order_total"]
         shipping_method = context_data["shipping_method"]
+        order_total = context_data["order_total"]
         customer_email = None
         try:
-            customer_email = context_data["basket"].owner.email
+            customer_email = basket.owner.email
         except AttributeError:
-            checkout_data = self.request.session[
-                self.checkout_session.SESSION_KEY
-            ]
+            checkout_data = self.request.session[self.checkout_session.SESSION_KEY]
             customer_email = checkout_data["guest"]["email"]
 
-        stripe_session = Facade().begin(
-            customer_email=customer_email,
+        stripe_session = Facade().create_checkout_session(
             basket=basket,
-            total=total,
+            order_total=order_total,
             shipping_method=shipping_method,
+            customer_email=customer_email,
         )
         stripe_session_id = stripe_session.id
-        stripe_payment_intent_id = stripe_session.payment_intent
-
         self.request.session["stripe_session_id"] = stripe_session_id
-        self.request.session["stripe_payment_intent_id"] = stripe_payment_intent_id
 
-        context_data.update({
-            "stripe_publishable_key": settings.STRIPE_PUBLISHABLE_KEY,
-            "stripe_session_id": stripe_session_id
-        })
+        context_data.update(
+            {
+                "stripe_publishable_key": settings.STRIPE_PUBLISHABLE_KEY,
+                "stripe_session_id": stripe_session_id,
+            }
+        )
         return context_data
 
 
-class StripeSCASuccessResponseView(CorePaymentDetailsView):
+class StripeSCAPreviewView(TwoStepPaymentMixin, CorePaymentDetailsView):
     preview = True
     template_name_preview = f"{PACKAGE_NAME}/stripe_preview.html"
 
@@ -86,115 +80,160 @@ class StripeSCASuccessResponseView(CorePaymentDetailsView):
 
     @method_decorator(csrf_exempt)
     def dispatch(self, request, *args, **kwargs):
-        return super(StripeSCASuccessResponseView, self).dispatch(
-            request, *args, **kwargs
-        )
+        return super().dispatch(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
-        ctx = super(StripeSCASuccessResponseView, self).get_context_data(**kwargs)
-        if ctx["order_total"] is None:
+        context_data = super().get_context_data(**kwargs)
+
+        if context_data["order_total"] is None:
             messages.error(
-                self.request, "Your checkout session has expired, please try again"
+                self.request,
+                "Your checkout session has expired, please try again",
             )
             raise PermissionDenied
         else:
-            ctx["order_total_incl_tax_cents"] = (
-                ctx["order_total"].incl_tax * 100
+            context_data["order_total_incl_tax_cents"] = (
+                context_data["order_total"].incl_tax * 100
             ).to_integral_value()
-        return ctx
 
-    def handle_payment(self, order_number, order_total, **kwargs):
-        pi = self.request.session["stripe_payment_intent_id"]
-        intent = Facade().retrieve_payment_intent(pi)
-        intent.capture()
-
-        source_type, __ = SourceType.objects.get_or_create(name=PAYMENT_METHOD_STRIPE)
-        source = Source(
-            source_type=source_type,
-            currency=order_total.currency,
-            amount_allocated=order_total.incl_tax,
-            amount_debited=order_total.incl_tax,
-            reference=pi,
-        )
-        self.add_payment_source(source)
-
-        self.add_payment_event(
-            PAYMENT_EVENT_PURCHASE, order_total.incl_tax, reference=pi
-        )
-
-        del self.request.session["stripe_session_id"]
-        del self.request.session["stripe_payment_intent_id"]
-
-    def payment_description(self, order_number, total, **kwargs):
-        return "Stripe payment for order {0} by {1}".format(
-            order_number, self.request.user.get_full_name()
-        )
-
-    @staticmethod
-    def payment_metadata(order_number, total, **kwargs):
-        return {
-            "order_number": order_number,
-        }
-
-    def load_frozen_basket(self, basket_id):
-        # Lookup the frozen basket that this txn corresponds to
-        try:
-            basket = Basket.objects.get(id=basket_id, status=Basket.FROZEN)
-        except Basket.DoesNotExist:
-            return None
-
-        # Assign strategy to basket instance
-        if Selector:
-            basket.strategy = Selector().strategy(self.request)
-
-        # Re-apply any offers
-        Applicator().apply(basket, self.request.user, request=self.request)
-
-        return basket
+        return context_data
 
     def get(self, request, *args, **kwargs):
-        kwargs["basket"] = self.load_frozen_basket(kwargs["basket_id"])
-        if not kwargs["basket"]:
-            logger.warning(
-                "Unable to load frozen basket with ID %s", kwargs["basket_id"]
-            )
-            messages.error(
-                self.request,
-                _("No basket was found that corresponds to your " "Stripe transaction"),
-            )
+        basket_id = kwargs["basket_id"]
+        basket = self.load_frozen_basket(basket_id, request.user, request)
+        if not basket:
             return HttpResponseRedirect(reverse("basket:summary"))
-        return super(StripeSCASuccessResponseView, self).get(request, *args, **kwargs)
+
+        kwargs["basket"] = basket
+        return super().get(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):
-        """
-        Place an order.
-        """
-        # Reload frozen basket which is specified in the URL
-        basket = self.load_frozen_basket(kwargs["basket_id"])
+        basket_id = kwargs["basket_id"]
+        basket = self.load_frozen_basket(basket_id, request.user, request)
         if not basket:
-            messages.error(
-                self.request,
-                _("No basket was found that corresponds to your Stripe transaction"),
-            )
             return HttpResponseRedirect(reverse("basket:summary"))
 
-        submission = self.build_submission(basket=basket)
-        return self.submit(**submission)
+        return self.submit_basket(basket)  # from TwoStepPaymentMixin
 
 
-class StripeSCACancelResponseView(RedirectView):
-    permanent = False
+@method_decorator(csrf_exempt, name="dispatch")
+class StripeSCAWebhookView(OneStepPaymentMixin, OrderPlacementMixin, View):
+
+    def post(self, request, *args, **kwargs):
+        payload = request.body
+        logger.info(f"*** Received Stripe webhook payload: {payload}")
+
+        signature = request.headers.get("stripe-signature")
+        try:
+            event = Facade().construct_event(payload, signature)
+        except SignatureVerificationError:
+            logger.error(f"*** Stripe signature verification error!")
+            return HttpResponse(status=400)
+        else:
+            event_type = event.type
+            logger.info(f"*** Stripe event: [{event_type}] --> {event}")
+
+        if event.type == "payment_intent.succeeded":
+            payment_intent_data = event.data.object
+            basket_id = payment_intent_data["metadata"]["basket_id"]
+            basket = self.load_frozen_basket(basket_id)
+
+            self.submit_basket(basket, payment_intent_data)  # from OneStepPaymentMixin
+
+        logger.info("*** Stripe webhook processing complete")
+        return HttpResponse(status=200)
+
+
+class StripeSCAPaymentStatusView(View):
+
+    def _check_payment_status(self, payment_intent_id):
+        logger.debug(f"*** Checking status of Payment Intent #{payment_intent_id}")
+
+        is_successful, order_id = False, -1
+
+        payment_events = PaymentEvent.objects.filter(
+            event_type__name=PAYMENT_EVENT_PURCHASE,
+            reference=payment_intent_id,
+        )
+        if payment_events.exists():
+            order = payment_events.first().order
+            logger.debug(f"*** Found matching Order #{order.number} (ID: {order.id})")
+
+            requested_amount = order.total_incl_tax
+            logger.debug(f"*** Requested amount: {requested_amount}")
+
+            received_amount = sum([event.amount for event in payment_events])
+            logger.debug(f"*** Received amount: {received_amount}")
+
+            is_successful = requested_amount == received_amount
+            order_id = order.id
+
+        return is_successful, order_id
 
     def get(self, request, *args, **kwargs):
-        basket = get_object_or_404(Basket, id=kwargs["basket_id"], status=Basket.FROZEN)
-        basket.thaw()
-        logger.info(
-            "Payment cancelled (token %s) - basket #%s thawed",
-            request.GET.get("token", "<no token>"),
-            basket.id,
+        session = self.request.session
+
+        checkout_session_id = session["stripe_session_id"]
+        payment_intent_id = Facade().retrieve_payment_intent_id(
+            checkout_session_id=checkout_session_id
         )
-        return super(StripeSCACancelResponseView, self).get(request, *args, **kwargs)
+        is_successful, order_id = self._check_payment_status(payment_intent_id)
+        if is_successful:
+            session["checkout_order_id"] = order_id  # for the ThankYou view
+
+        response_data = {
+            "paymentIntentID": payment_intent_id,
+            "isSuccessful": is_successful,
+            "orderId": order_id,
+        }
+        return JsonResponse(response_data)
+
+
+class StripeSCAWaitingView(TemplateView):
+    template_name = f"{PACKAGE_NAME}/stripe_waiting.html"
+
+    def _get_payment_status_url(self):
+        return Facade()._get_payment_status_url()
+
+    def _get_payment_success_url(self):
+        return Facade()._get_order_confirmation_url()
+
+    def _get_payment_polling_interval(self):
+        return settings.STRIPE_PAYMENT_POLLING_INTERVAL
+
+    def get_context_data(self, **kwargs):
+        context_data = super().get_context_data(**kwargs)
+
+        payment_status_url = self._get_payment_status_url()
+        payment_success_url = self._get_payment_success_url()
+        polling_interval = self._get_payment_polling_interval()
+
+        context_data.update(
+            {
+                "payment_status_url": payment_status_url,
+                "payment_success_url": payment_success_url,
+                "polling_interval": polling_interval,
+            }
+        )
+        return context_data
+
+
+class StripeSCACancelView(StripePaymentMixin, RedirectView):
+    permanent = False
 
     def get_redirect_url(self, **kwargs):
-        messages.error(self.request, _("Stripe transaction cancelled"))
         return reverse("basket:summary")
+
+    def get(self, request, *args, **kwargs):
+        basket_id = kwargs["basket_id"]
+        basket = self.load_frozen_basket(basket_id, request.user, request)
+        if basket:
+            basket.thaw()
+            logger.info(
+                "*** Stripe transaction cancelled, basket #%s thawed",
+                basket.id,
+            )
+
+        messages.error(self.request, _("Stripe transaction cancelled"))
+
+        return super().get(request, *args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "flit_scm:buildapi"
 
 [project]
 name = "django-oscar-stripe-sca"
-version = "0.8.2-1"
-description = "Stripe Checkout (with Payment Intents) payment module for django-oscar"
+version = "0.8.2-2"
+description = "Stripe Checkout payment module for django-oscar"
 readme = "README.rst"
 license = "MIT"
 license-files = ["LICENSE"]

--- a/runtests.py
+++ b/runtests.py
@@ -9,52 +9,53 @@ raise NotImplementedError("I've not looked at these yet.")
 
 if not settings.configured:
     settings.configure(
-            DATABASES={
-                'default': {
-                    'ENGINE': 'django.db.backends.sqlite3',
-                    }
-                },
-            INSTALLED_APPS=[
-                'django.contrib.auth',
-                'django.contrib.admin',
-                'django.contrib.contenttypes',
-                'django.contrib.sessions',
-                'django.contrib.sites',
-                'oscar_stripe',
-                'south',
-                ],
-            DEBUG=False,
-            SITE_ID=1,
-            NOSE_ARGS=['-s', '--with-spec'],
-        )
+        DATABASES={
+            "default": {
+                "ENGINE": "django.db.backends.sqlite3",
+            }
+        },
+        INSTALLED_APPS=[
+            "django.contrib.auth",
+            "django.contrib.admin",
+            "django.contrib.contenttypes",
+            "django.contrib.sessions",
+            "django.contrib.sites",
+            "oscar_stripe",
+            "south",
+        ],
+        DEBUG=False,
+        SITE_ID=1,
+        NOSE_ARGS=["-s", "--with-spec"],
+    )
 
 # Needs to be here to avoid missing SETTINGS env var
 from django_nose import NoseTestSuiteRunner
 
 
 def run_tests(*test_args):
-    if 'south' in settings.INSTALLED_APPS:
+    if "south" in settings.INSTALLED_APPS:
         from south.management.commands import patch_for_test_db_setup
+
         patch_for_test_db_setup()
 
     if not test_args:
-        test_args = ['tests']
+        test_args = ["tests"]
 
     # Run tests
     test_runner = NoseTestSuiteRunner(verbosity=1)
 
-    c = coverage(source=['oscar_stripe'], omit=['*migrations*', '*tests*'])
+    c = coverage(source=["oscar_stripe"], omit=["*migrations*", "*tests*"])
     c.start()
     num_failures = test_runner.run_tests(test_args)
     c.stop()
 
     if num_failures > 0:
         sys.exit(num_failures)
-    print "Generating HTML coverage report"
+    print("Generating HTML coverage report")
     c.html_report()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = OptionParser()
     (options, args) = parser.parse_args()
     run_tests(*args)

--- a/sandbox/apps/checkout/apps.py
+++ b/sandbox/apps/checkout/apps.py
@@ -3,11 +3,12 @@ from oscar.apps.checkout.apps import CheckoutConfig
 
 
 class StripeSCASandboxCheckoutConfig(CheckoutConfig):
-    name = 'apps.checkout'
+    name = "apps.checkout"
 
     def ready(self):
         super().ready()
         from oscar_stripe_sca import views as stripe_sca_views
+
         self.payment_details_view = stripe_sca_views.StripeSCAPaymentDetailsView
         self.stripe_success_view = stripe_sca_views.StripeSCASuccessResponseView
         self.stripe_cancel_view = stripe_sca_views.StripeSCACancelResponseView
@@ -15,9 +16,15 @@ class StripeSCASandboxCheckoutConfig(CheckoutConfig):
     def get_urls(self):
         urls = super().get_urls()
         urls += [
-            re_path(r'preview-stripe/(?P<basket_id>\d+)/$',
-                self.stripe_success_view.as_view(preview=True), name='stripe-preview'),
-            re_path(r'stripe-payment-cancel/(?P<basket_id>\d+)/$',
-                self.stripe_cancel_view.as_view(), name='stripe-cancel'),
+            re_path(
+                r"preview-stripe/(?P<basket_id>\d+)/$",
+                self.stripe_success_view.as_view(preview=True),
+                name="stripe-preview",
+            ),
+            re_path(
+                r"stripe-payment-cancel/(?P<basket_id>\d+)/$",
+                self.stripe_cancel_view.as_view(),
+                name="stripe-cancel",
+            ),
         ]
         return urls

--- a/sandbox/apps/checkout/views.py
+++ b/sandbox/apps/checkout/views.py
@@ -3,4 +3,3 @@ from oscar.apps.checkout.views import PaymentDetailsView as OscarPaymentDetailsV
 
 class StripeSCASandboxPaymentDetailsView(OscarPaymentDetailsView):
     pass
-

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -12,28 +12,28 @@ ADMINS = (
     # ('Your Name', 'your_email@domain.com'),
 )
 
-EMAIL_BACKEND = 'django.core.mail.backends.filebased.EmailBackend'
+EMAIL_BACKEND = "django.core.mail.backends.filebased.EmailBackend"
 EMAIL_FILE_PATH = os.path.join(PROJECT_DIR, "emails")
 
 MANAGERS = ADMINS
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': location('db.sqlite'),                      # Or path to database file if using sqlite3.
-        'ATOMIC_REQUESTS': True,
-        'USER': '',                      # Not used with sqlite3.
-        'PASSWORD': '',                  # Not used with sqlite3.
-        'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.
-        'PORT': '',                      # Set to empty string for default. Not used with sqlite3.
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",  # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
+        "NAME": location("db.sqlite"),  # Or path to database file if using sqlite3.
+        "ATOMIC_REQUESTS": True,
+        "USER": "",  # Not used with sqlite3.
+        "PASSWORD": "",  # Not used with sqlite3.
+        "HOST": "",  # Set to empty string for localhost. Not used with sqlite3.
+        "PORT": "",  # Set to empty string for default. Not used with sqlite3.
     }
 }
 
-TIME_ZONE = 'Europe/London'
+TIME_ZONE = "Europe/London"
 
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = "en-us"
 
 SITE_ID = 1
 
@@ -52,49 +52,49 @@ MEDIA_ROOT = location("public/media")
 # URL that handles the media served from MEDIA_ROOT. Make sure to use a
 # trailing slash if there is a path component (optional in other cases).
 # Examples: "http://media.lawrence.com", "http://example.com/media/"
-MEDIA_URL = '/media/'
+MEDIA_URL = "/media/"
 
 # URL prefix for admin media -- CSS, JavaScript and images. Make sure to use a
 # trailing slash.
 # Examples: "http://foo.com/media/", "/media/".
-#ADMIN_MEDIA_PREFIX = '/media/admin/'
+# ADMIN_MEDIA_PREFIX = '/media/admin/'
 
-STATIC_URL = '/static/'
-STATICFILES_DIRS = (location('static/'),)
+STATIC_URL = "/static/"
+STATICFILES_DIRS = (location("static/"),)
 STATICFILES_FINDERS = (
-    'django.contrib.staticfiles.finders.FileSystemFinder',
-    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    "django.contrib.staticfiles.finders.FileSystemFinder",
+    "django.contrib.staticfiles.finders.AppDirectoriesFinder",
 )
 
 # Make this unique, and don't share it with anybody.
-SECRET_KEY = '!8(8ijbn^rd%y%ckok%ju_tce+g)iv09vog*ut#9^5-9uc&rhs'
+SECRET_KEY = "!8(8ijbn^rd%y%ckok%ju_tce+g)iv09vog*ut#9^5-9uc&rhs"
 
 
 MIDDLEWARE = [
-    'django.middleware.common.CommonMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'oscar.apps.basket.middleware.BasketMiddleware',
+    "django.middleware.common.CommonMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.contrib.flatpages.middleware.FlatpageFallbackMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "oscar.apps.basket.middleware.BasketMiddleware",
 ]
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
-INTERNAL_IPS = ('127.0.0.1',)
+INTERNAL_IPS = ("127.0.0.1",)
 
-ROOT_URLCONF = 'urls'
+ROOT_URLCONF = "urls"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [
-            os.path.join(PROJECT_DIR, 'templates'),
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [
+            os.path.join(PROJECT_DIR, "templates"),
         ],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
                 "django.contrib.auth.context_processors.auth",
                 "django.template.context_processors.request",
                 "django.template.context_processors.debug",
@@ -103,135 +103,131 @@ TEMPLATES = [
                 "django.template.context_processors.static",
                 "django.contrib.messages.context_processors.messages",
                 # Oscar specific
-                'oscar.apps.search.context_processors.search_form',
-                'oscar.apps.checkout.context_processors.checkout',
-                'oscar.apps.communication.notifications.context_processors.notifications',
-                'oscar.core.context_processors.metadata',
+                "oscar.apps.search.context_processors.search_form",
+                "oscar.apps.checkout.context_processors.checkout",
+                "oscar.apps.communication.notifications.context_processors.notifications",
+                "oscar.core.context_processors.metadata",
             ]
-        }
+        },
     }
 ]
 
 LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'formatters': {
-        'verbose': {
-            'format': '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s'
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "verbose": {
+            "format": "%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s"
         },
-        'simple': {
-            'format': '%(levelname)s %(message)s'
+        "simple": {"format": "%(levelname)s %(message)s"},
+    },
+    "handlers": {
+        "null": {
+            "level": "DEBUG",
+            "class": "logging.NullHandler",
+        },
+        "console": {
+            "level": "DEBUG",
+            "class": "logging.StreamHandler",
+            "formatter": "verbose",
+        },
+        "oscar_stripe_file": {
+            "level": "DEBUG",
+            "class": "logging.FileHandler",
+            "filename": os.path.join(PROJECT_DIR, "logs", "oscar_stripe_sca.log"),
+            "formatter": "verbose",
+        },
+        "mail_admins": {
+            "level": "ERROR",
+            "class": "django.utils.log.AdminEmailHandler",
         },
     },
-    'handlers': {
-        'null': {
-            'level': 'DEBUG',
-            'class': 'logging.NullHandler',
+    "loggers": {
+        "django": {
+            "handlers": ["null"],
+            "propagate": True,
+            "level": "INFO",
         },
-        'console': {
-            'level': 'DEBUG',
-            'class': 'logging.StreamHandler',
-            'formatter': 'verbose'
+        "django.request": {
+            "handlers": ["mail_admins"],
+            "level": "ERROR",
+            "propagate": False,
         },
-        'oscar_stripe_file': {
-             'level': 'DEBUG',
-             'class': 'logging.FileHandler',
-             'filename': os.path.join(PROJECT_DIR, 'logs', 'oscar_stripe_sca.log'),
-             'formatter': 'verbose'
+        "oscar.checkout": {
+            "handlers": ["console"],
+            "propagate": True,
+            "level": "INFO",
         },
-        'mail_admins': {
-            'level': 'ERROR',
-            'class': 'django.utils.log.AdminEmailHandler',
+        "django.db.backends": {
+            "handlers": ["null"],
+            "propagate": False,
+            "level": "DEBUG",
+        },
+        "oscar_stripe_sca": {
+            "handlers": ["console", "oscar_stripe_file"],
+            "propagate": True,
+            "level": "DEBUG",
         },
     },
-    'loggers': {
-        'django': {
-            'handlers': ['null'],
-            'propagate': True,
-            'level':'INFO',
-        },
-        'django.request': {
-            'handlers': ['mail_admins'],
-            'level': 'ERROR',
-            'propagate': False,
-        },
-        'oscar.checkout': {
-            'handlers': ['console'],
-            'propagate': True,
-            'level': 'INFO',
-        },
-        'django.db.backends': {
-            'handlers': ['null'],
-            'propagate': False,
-            'level': 'DEBUG',
-        },
-        'oscar_stripe_sca': {
-            'handlers': ['console', 'oscar_stripe_file'],
-            'propagate': True,
-            'level': 'DEBUG',
-        },
-    }
 }
 
 
 INSTALLED_APPS = [
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.sites',
-    'django.contrib.messages',
-    'django.contrib.admin',
-    'django.contrib.flatpages',
-    'django.contrib.staticfiles',
-    'widget_tweaks',
-    'django_tables2',
-    'sorl.thumbnail',
-    'oscar.config.Shop',
-    'oscar.apps.address.apps.AddressConfig',
-
-    'apps.checkout.apps.StripeSCASandboxCheckoutConfig',
-
-    'oscar.apps.dashboard.apps.DashboardConfig',
-    'oscar.apps.partner.apps.PartnerConfig',
-    'oscar.apps.basket.apps.BasketConfig',
-    'oscar.apps.order.apps.OrderConfig',
-    'oscar.apps.customer.apps.CustomerConfig',
-    'oscar.apps.shipping.apps.ShippingConfig',
-    'oscar.apps.dashboard.reports.apps.ReportsDashboardConfig',
-    'oscar.apps.analytics.apps.AnalyticsConfig',
-    'oscar.apps.catalogue.apps.CatalogueConfig',
-    'oscar.apps.catalogue.reviews.apps.CatalogueReviewsConfig',
-    'oscar.apps.communication.apps.CommunicationConfig',
-    'oscar.apps.payment.apps.PaymentConfig',
-    'oscar.apps.offer.apps.OfferConfig',
-    'oscar.apps.search.apps.SearchConfig',
-    'oscar.apps.voucher.apps.VoucherConfig',
-    'oscar.apps.wishlists.apps.WishlistsConfig',
-    'oscar.apps.dashboard.users.apps.UsersDashboardConfig',
-    'oscar.apps.dashboard.orders.apps.OrdersDashboardConfig',
-    'oscar.apps.dashboard.catalogue.apps.CatalogueDashboardConfig',
-    'oscar.apps.dashboard.offers.apps.OffersDashboardConfig',
-    'oscar.apps.dashboard.partners.apps.PartnersDashboardConfig',
-    'oscar.apps.dashboard.pages.apps.PagesDashboardConfig',
-    'oscar.apps.dashboard.ranges.apps.RangesDashboardConfig',
-    'oscar.apps.dashboard.reviews.apps.ReviewsDashboardConfig',
-    'oscar.apps.dashboard.vouchers.apps.VouchersDashboardConfig',
-    'oscar.apps.dashboard.communications.apps.CommunicationsDashboardConfig',
-    'oscar.apps.dashboard.shipping.apps.ShippingDashboardConfig',
-    'oscar_stripe_sca',
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.sites",
+    "django.contrib.messages",
+    "django.contrib.admin",
+    "django.contrib.flatpages",
+    "django.contrib.staticfiles",
+    "widget_tweaks",
+    "django_tables2",
+    "sorl.thumbnail",
+    "oscar.config.Shop",
+    "oscar.apps.address.apps.AddressConfig",
+    "apps.checkout.apps.StripeSCASandboxCheckoutConfig",
+    "oscar.apps.dashboard.apps.DashboardConfig",
+    "oscar.apps.partner.apps.PartnerConfig",
+    "oscar.apps.basket.apps.BasketConfig",
+    "oscar.apps.order.apps.OrderConfig",
+    "oscar.apps.customer.apps.CustomerConfig",
+    "oscar.apps.shipping.apps.ShippingConfig",
+    "oscar.apps.dashboard.reports.apps.ReportsDashboardConfig",
+    "oscar.apps.analytics.apps.AnalyticsConfig",
+    "oscar.apps.catalogue.apps.CatalogueConfig",
+    "oscar.apps.catalogue.reviews.apps.CatalogueReviewsConfig",
+    "oscar.apps.communication.apps.CommunicationConfig",
+    "oscar.apps.payment.apps.PaymentConfig",
+    "oscar.apps.offer.apps.OfferConfig",
+    "oscar.apps.search.apps.SearchConfig",
+    "oscar.apps.voucher.apps.VoucherConfig",
+    "oscar.apps.wishlists.apps.WishlistsConfig",
+    "oscar.apps.dashboard.users.apps.UsersDashboardConfig",
+    "oscar.apps.dashboard.orders.apps.OrdersDashboardConfig",
+    "oscar.apps.dashboard.catalogue.apps.CatalogueDashboardConfig",
+    "oscar.apps.dashboard.offers.apps.OffersDashboardConfig",
+    "oscar.apps.dashboard.partners.apps.PartnersDashboardConfig",
+    "oscar.apps.dashboard.pages.apps.PagesDashboardConfig",
+    "oscar.apps.dashboard.ranges.apps.RangesDashboardConfig",
+    "oscar.apps.dashboard.reviews.apps.ReviewsDashboardConfig",
+    "oscar.apps.dashboard.vouchers.apps.VouchersDashboardConfig",
+    "oscar.apps.dashboard.communications.apps.CommunicationsDashboardConfig",
+    "oscar.apps.dashboard.shipping.apps.ShippingDashboardConfig",
+    "oscar_stripe_sca",
 ]
 
 AUTHENTICATION_BACKENDS = (
-    'django.contrib.auth.backends.ModelBackend',
-    'oscar.apps.customer.auth_backends.EmailBackend'
+    "django.contrib.auth.backends.ModelBackend",
+    "oscar.apps.customer.auth_backends.EmailBackend",
 )
 
-LOGIN_REDIRECT_URL = '/accounts/'
+LOGIN_REDIRECT_URL = "/accounts/"
 APPEND_SLASH = True
 
 HAYSTACK_CONNECTIONS = {
-    'default': {
-        'ENGINE': 'haystack.backends.simple_backend.SimpleEngine',
+    "default": {
+        "ENGINE": "haystack.backends.simple_backend.SimpleEngine",
     },
 }
 
@@ -258,5 +254,9 @@ STRIPE_RETURN_URL_BASE = "https://www.example.com/"
 # If you don't want to use a settings_local.py, comment or remove this line.
 from settings_local import *
 
-STRIPE_PAYMENT_SUCCESS_URL = "{0}{1}".format(STRIPE_RETURN_URL_BASE, "/checkout/preview-stripe/{0}/")
-STRIPE_PAYMENT_CANCEL_URL = "{0}{1}".format(STRIPE_RETURN_URL_BASE, "/checkout/stripe-payment-cancel/{0}/")
+STRIPE_PAYMENT_SUCCESS_URL = "{0}{1}".format(
+    STRIPE_RETURN_URL_BASE, "/checkout/preview-stripe/{0}/"
+)
+STRIPE_PAYMENT_CANCEL_URL = "{0}{1}".format(
+    STRIPE_RETURN_URL_BASE, "/checkout/stripe-payment-cancel/{0}/"
+)

--- a/sandbox/urls.py
+++ b/sandbox/urls.py
@@ -9,9 +9,9 @@ from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 admin.autodiscover()
 
 urlpatterns = [
-    path('admin', admin.site.urls),
-    path('i18n', include(i18n)),
-    path('', include(apps.get_app_config('oscar').urls[0])),
+    path("admin", admin.site.urls),
+    path("i18n", include(i18n)),
+    path("", include(apps.get_app_config("oscar").urls[0])),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
### Overview

This PR has the main effect of adding the possibility to remove the _Order Preview_ step from the standard Oscar checkout flow, which may be deemed necessary in order to improve the user experience during checkout and maximize conversion.

This behavior is driven by the following, newly-introduced [settings](https://github.com/nngroup/django-oscar-stripe-sca/pull/3/files#diff-de0f2e01cbaa69148cce09119a8a3a10bf82a4a419ea1094efd5cbad6d3f4912R46-R55):

- `STRIPE_BYPASS_ORDER_PREVIEW`: set to `True` to remove the _Order Preview_ step.
- `STRIPE_WAIT_FOR_PAYMENT_CONFIRMATION`: set to `True` to add a _Waiting_ step — basically, to make sure the payment is actually successful before showing the _Order Confirmation_ page.
- `STRIPE_PAYMENT_POLLING_INTERVAL`: optional, set to the time (in milliseconds) to wait between each payment status poll. Defaults to `1000`.
- `STRIPE_WEBHOOK_ENDPOINT_SECRET`: set to a secret, provided by Stripe, allowing verification of the integrity of the received webhook messages.

### Flows

The classic Oscar-Stripe checkout flow only _authorizes_ the user's payment during their initial interaction with Stripe Checkout, and the payment is then _captured_ when they click on the _Place Order_ button on the _Order Preview_ page. We will thus call it the _**two-step payment flow**_:

```
+-------+                              +---------+                          +---------+
| User  |                              | Website |                          | Stripe  |
+-------+                              +---------+                          +---------+
    |                                       |                                    |
    | Start checkout                        |                                    |
    |-------------------------------------->|                                    |
    |                                       |                                    |
    |                                       | Create Checkout Session            |
    |                                       |----------------------------------->|
    |                                       |                                    |
    |                                       |                Checkout Session ID |
    |                                       |<-----------------------------------|
    |                                       |                                    |
    |                                       | Redirect to "Stripe Checkout"      |
    |                                       |----------------------------------->|
    |                                       |                                    |
    | STEP 1: Input payment details         |                                    |
    |--------------------------------------------------------------------------->|
    |                                       |                                    | --------------------\
    |                                       |                                    |-| AUTHORIZE PAYMENT |
    |                                       |                                    | |-------------------|
    |                                       |                                    |
    |                                       |        Redirect to "Order Preview" |
    |<---------------------------------------------------------------------------|
    |                                       |                                    |
    | STEP 2: Click "Place Order"           |                                    |
    |-------------------------------------->|                                    |
    |                                       |                                    |
    |                                       | Payment capture order              |
    |                                       |----------------------------------->|
    |                                       |                                    | ------------------\
    |                                       |                                    |-| CAPTURE PAYMENT |
    |                                       |                                    | |-----------------|
    |                                       |                                    |
    |                                       |                 Payment capture OK |
    |                                       |<-----------------------------------|
    |                                       | --------------\                    |
    |                                       |-| PLACE ORDER |                    |
    |                                       | |-------------|                    |
    |                                       |                                    |
    |      Redirect to "Order Confirmation" |                                    |
    |<--------------------------------------|                                    |
    |                                       |                                    |
```

Conversely, the flow enabled by this PR has authorization and capture happen right after another, without any intermediate user confirmation, thus earning the name of _**one-step payment flow**_:

```
+-------+                              +---------+                          +---------+
| User  |                              | Website |                          | Stripe  |
+-------+                              +---------+                          +---------+
    |                                       |                                    |
    | Start checkout                        |                                    |
    |-------------------------------------->|                                    |
    |                                       |                                    |
    |                                       | Create Checkout Session            |
    |                                       |----------------------------------->|
    |                                       |                                    |
    |                                       |                Checkout Session ID |
    |                                       |<-----------------------------------|
    |                                       |                                    |
    |                                       | Redirect to "Stripe Checkout"      |
    |                                       |----------------------------------->|
    |                                       |                                    |
    | STEP 1: Input payment details         |                                    |
    |--------------------------------------------------------------------------->|
    |                                       |                                    | --------------------\
    |                                       |                                    |-| AUTHORIZE PAYMENT |
    |                                       |                                    | |-------------------|
    |                                       |                                    |
    |                                       |           Redirect to "Waiting..." |
    |<---------------------------------------------------------------------------|
    |                                       |                                    | ------------------\
    |                                       |                                    |-| CAPTURE PAYMENT |
    |                                       |                                    | |-----------------|
    |                                       |                                    |
    |                                       |       Payment confirmation webhook |
    |                                       |<-----------------------------------|
    |                                       | --------------\                    |
    |                                       |-| PLACE ORDER |                    |
    |                                       | |-------------|                    |
    |                                       |                                    |
    |                                       | Acknowledge webhook                |
    |                                       |----------------------------------->|
    |                                       |                                    |
    |      Redirect to "Order Confirmation" |                                    |
    |<--------------------------------------|                                    |
    |                                       |                                    |
```
(diagrams courtesy of https://textart.io/sequence)

### Implementation

As previously, `facade.py` contains the whole logic to interact with the Stripe [CheckoutSession](https://github.com/nngroup/django-oscar-stripe-sca/pull/3/files#diff-ee1f7aaee06ce91fc0dd3b41347baaee7c6dfe52dd1a28dab8d463905f54fa68R327) and [PaymentIntent](https://github.com/nngroup/django-oscar-stripe-sca/pull/3/files#diff-ee1f7aaee06ce91fc0dd3b41347baaee7c6dfe52dd1a28dab8d463905f54fa68R371) objects.

A significant challenge, however, lies in the fact that the two-step flow _heavily_ relies on the user session to build and ultimately place the order — something that has to happen [_in response to the webhook `POST`_](https://github.com/nngroup/django-oscar-stripe-sca/pull/3/files#diff-db80f2743fe60b0369ee12fda269d17cbfc38e210459844f2e21a1ab76ef4f36R120) in the one-step flow. 

Our solution here is to [leverage the](https://github.com/nngroup/django-oscar-stripe-sca/pull/3/files#diff-ee1f7aaee06ce91fc0dd3b41347baaee7c6dfe52dd1a28dab8d463905f54fa68R172-R176) [Stripe](https://github.com/nngroup/django-oscar-stripe-sca/pull/3/files#diff-db80f2743fe60b0369ee12fda269d17cbfc38e210459844f2e21a1ab76ef4f36R138) [metadata](https://github.com/nngroup/django-oscar-stripe-sca/pull/3/files#diff-3a294b3d241675a4ba576e040577510bf8443c3241a847369cdf90add30f0e32R154) to gain the ability to [submit the basket](https://github.com/nngroup/django-oscar-stripe-sca/pull/3/files#diff-3a294b3d241675a4ba576e040577510bf8443c3241a847369cdf90add30f0e32R166) and [place the order](https://github.com/nngroup/django-oscar-stripe-sca/pull/3/files#diff-3a294b3d241675a4ba576e040577510bf8443c3241a847369cdf90add30f0e32R189) without relying on the actual user session.

Meanwhile, the user sees a basic (but customizable, as ever) [_Waiting..._](https://github.com/nngroup/django-oscar-stripe-sca/pull/3/files#diff-db80f2743fe60b0369ee12fda269d17cbfc38e210459844f2e21a1ab76ef4f36R192) page, which itself [polls](https://github.com/nngroup/django-oscar-stripe-sca/pull/3/files#diff-9947ed6dd4d108dd98d5a53293fe2d00151f443c77a79743f3c1bf30a6531c2cR27-R50) the [PaymentStatus](https://github.com/nngroup/django-oscar-stripe-sca/pull/3/files#diff-db80f2743fe60b0369ee12fda269d17cbfc38e210459844f2e21a1ab76ef4f36R147) view, and ultimately redirects the user to the _Order Confirmation_ page 🏁 

### Review tips

- The PR can be tested on the following review app: https://nngroup-pr-3935.herokuapp.com/
- All changes in the `sandbox` directory may be ignored, they are merely cosmetic due to `black` code linting.
