### PR TITLE
feat: enhance Facade

### DIFF
--- a/oscar_stripe_sca/facade.py
+++ b/oscar_stripe_sca/facade.py
@@ -449,15 +449,35 @@ class Facade:
     def before_checkout_start(self, request, **kwargs):
         pass
 
-    def retrieve_checkout_session(self, checkout_session_id=None, payment_intent_id=None):
-        if not checkout_session_id:
-            if not payment_intent_id:
-                raise ValueError()
+    def retrieve_checkout_session(self, checkout_session_id=None, payment_intent_id=None, params={}):
+        """
+        Retrieve a Stripe Checkout Session.
 
-            params = {"payment_intent": payment_intent_id}
+        If a payment intent ID is provided, it will be used to filter the sessions.
+        If a checkout session ID is provided, it will be used to retrieve the session.
+        If no ID is provided, an error will be raised.
+
+        Parameters:
+        - checkout_session_id: The ID of the checkout session to retrieve.
+        - payment_intent_id: The ID of the payment intent to filter the sessions by.
+        - params: Additional parameters to pass to the API call.
+        
+        A note on params: it has a different format depending on the method used. Example:
+        - list: {"expand": ["data.total_details.breakdown"]}
+        - retrieve: "expand": ["total_details.breakdown"]
+
+        Returns:
+        - The Stripe Checkout Session.
+        """
+
+        if not checkout_session_id and not payment_intent_id:
+            raise ValueError()
+
+        if payment_intent_id:
+            params.update({"payment_intent": payment_intent_id})
             return self.stripe_client.checkout.sessions.list(params=params).data[0]
 
-        return self.stripe_client.checkout.sessions.retrieve(checkout_session_id)
+        return self.stripe_client.checkout.sessions.retrieve(checkout_session_id, params=params)
 
     def retrieve_checkout_session_lines(self, checkout_session):
         return self.stripe_client.checkout.sessions.line_items.list(checkout_session.id)

--- a/oscar_stripe_sca/facade.py
+++ b/oscar_stripe_sca/facade.py
@@ -766,9 +766,10 @@ class Facade:
         results = self.stripe_client.invoices.search(params={"number": invoice_number})
         try:
             invoice_id = results["data"][0]["id"]
-            return self.retrieve_invoice(invoice_id)
         except IndexError:
             return None
+        else:
+            return self.retrieve_invoice(invoice_id)
 
     def record_invoice(self, invoice_id, payment_intent_id):
         raise NotImplementedError  # Implement before calling!

--- a/oscar_stripe_sca/facade.py
+++ b/oscar_stripe_sca/facade.py
@@ -761,6 +761,14 @@ class Facade:
 
     def retrieve_invoice(self, invoice_id):
         return self.stripe_client.invoices.retrieve(invoice_id)
+    
+    def retrieve_invoice_by_invoice_number(self, invoice_number):
+        results = self.stripe_client.invoices.search(params={"number": invoice_number})
+        try:
+            invoice_id = results["data"][0]["id"]
+            return self.retrieve_invoice(invoice_id)
+        except IndexError:
+            return None
 
     def record_invoice(self, invoice_id, payment_intent_id):
         raise NotImplementedError  # Implement before calling!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_scm:buildapi"
 
 [project]
 name = "django-oscar-stripe-sca"
-version = "0.8.2-13"
+version = "0.8.2-14"
 description = "Stripe Checkout payment module for django-oscar"
 readme = "README.rst"
 license = "MIT"


### PR DESCRIPTION
Enhancements to `Facade`:

* allow passing "params" to `retrieve_checkout_session`: this allows, for instance, passing instructions to "expand" specific response items such as `total_details.breakdown` which is required for our reporting purposes
* add `retrieve_invoice_by_invoice_number` from `Order` entity; another handy function required for the work being done in reports