### PR TITLE
feat: pass request and basket to selector

### DIFF
--- a/oscar_stripe_sca/mixins.py
+++ b/oscar_stripe_sca/mixins.py
@@ -61,9 +61,14 @@ class StripePaymentMixin:
         else:
             user = user or basket.owner
 
-        # Assign strategy to basket instance
+        # Assign strategy to basket instance.
+        # Pass request and basket so project Selectors can use request data
+        # and/or basket attributes (e.g. is_personal_purchase) when no POST
+        # body is available (webhook / preview / cancel).
         if StrategySelector:
-            basket.strategy = StrategySelector().strategy(user=user)
+            basket.strategy = StrategySelector().strategy(
+                user=user, request=request, basket=basket
+            )
 
         # Re-apply any offers
         OfferApplicator().apply(basket, user=user, request=request)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_scm:buildapi"
 
 [project]
 name = "django-oscar-stripe-sca"
-version = "0.8.2-16"
+version = "0.8.2-17"
 description = "Stripe Checkout payment module for django-oscar"
 readme = "README.rst"
 license = "MIT"


### PR DESCRIPTION
## Rationale

Pass request and basket so project `Selector`s can use request data and/or basket attributes (e.g. `is_personal_purchase`) when no `POST` body is available (webhook / preview / cancel).